### PR TITLE
 Mark update success in application & flash use refactor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,14 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          - smartcoaster-bootloader
+          - smartcoaster-application
 
     steps:
-
       - uses: actions/checkout@v4
       - name: Cache
         uses: actions/cache@v4
@@ -32,24 +35,28 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Add required target
         run: rustup target add thumbv6m-none-eabi
-      - name: Build
-        run: |
-          cargo build --release --package smartcoaster-bootloader
-          cargo build --release --package smartcoaster-application
-      - name: Upload bootloader
+      - name: Build ${{ matrix.package }}
+        run: cargo build --release --package ${{ matrix.package }}
+      - name: Upload ${{ matrix.package }}
         uses: actions/upload-artifact@v4
         with:
-          name: smartcoaster-bootloader
-          path: target/thumbv6m-none-eabi/release/smartcoaster-bootloader
-      - name: Upload application
-        uses: actions/upload-artifact@v4
-        with:
-          name: smartcoaster-application
-          path: target/thumbv6m-none-eabi/release/smartcoaster-application
+          name: ${{ matrix.package }}
+          path: target/thumbv6m-none-eabi/release/${{ matrix.package }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
       - name: Release
         uses: softprops/action-gh-release@v2
-        if: github.ref_type == 'tag'
         with:
-          files: target/thumbv6m-none-eabi/release/Smartcoaster
+          files: |
+            smartcoaster-bootloader/smartcoaster-bootloader
+            smartcoaster-application/smartcoaster-application
           draft: yes
           generate_release_notes: yes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ dependencies = [
  "defmt 1.0.1",
  "defmt-rtt",
  "ds323x",
+ "embassy-boot",
  "embassy-boot-rp",
  "embassy-embedded-hal",
  "embassy-executor",

--- a/TASK NOTES.md
+++ b/TASK NOTES.md
@@ -26,9 +26,10 @@ This is a scratch pad of notes to track ideas. Don't take it too seriously.
 ### Feature List
 
 * Firmware update via USB - *WIP*
-    * Add bootloader
-    * Modify flash interfaces used by settings to play nicely with bootloader
-    * Add firmware transfer via Serial over USB
+    * ~~Add bootloader~~
+    * ~~Modify flash interfaces used by settings to play nicely with bootloader~~
+    * Add USB interface to bootloader - activates if encoder held during boot
+    * Add firmware transfer via Serial over USB in bootloader DFU mode
     * Basic firmware update web page that uses web serial to transfer firmware
     * Bootloader shows screens to indicate update activity
 * Time to drink reminder mode (flash LED when time since last drink has elapsed)
@@ -57,6 +58,7 @@ This is a scratch pad of notes to track ideas. Don't take it too seriously.
 * Historical log of consumption
     * ~~Store history~~
     * ~~Read history~~
+    * Move to its own partition object
     * can be viewed as a graph on device (sparkline?)
     * or transferred via USB.
 

--- a/smartcoaster-application/Cargo.toml
+++ b/smartcoaster-application/Cargo.toml
@@ -46,6 +46,7 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 ds323x = "0.6.0"
 chrono = { version = "0.4.41", default-features = false, features = ["serde"] }
 embedded-icon = { version = "0.0.1", features = ["32px", "48px", "24px", "iconoir", "mdi"] }
+embassy-boot = "0.6.1"
 
 
 [build-dependencies]

--- a/smartcoaster-application/src/main.rs
+++ b/smartcoaster-application/src/main.rs
@@ -189,7 +189,7 @@ static CORE1_LOW_PRIO_EXECUTOR: StaticCell<Executor> = StaticCell::new();
 
 #[interrupt]
 unsafe fn SWI_IRQ_0() {
-    CORE0_HIGH_PRIO_EXECUTOR.on_interrupt()
+    unsafe { CORE0_HIGH_PRIO_EXECUTOR.on_interrupt() }
 }
 
 #[entry]

--- a/smartcoaster-application/src/main.rs
+++ b/smartcoaster-application/src/main.rs
@@ -113,13 +113,12 @@ const _NVM_PAGE_SIZE: usize = 256;
 
 // Application NVM for settings and activity log is at the end of flash
 const SETTINGS_SIZE: usize = 0x2000;
-const SETTINGS_NVM_FLASH_OFFSET_RANGE: Range<u32> =
-    (FLASH_SIZE - SETTINGS_SIZE) as u32..FLASH_SIZE as u32;
-
 const ACTIVITY_LOG_SIZE: usize = 0x8000;
-const ACTIVITY_LOG_NVM_FLASH_OFFSET_RANGE: Range<u32> = (SETTINGS_NVM_FLASH_OFFSET_RANGE.start
-    - ACTIVITY_LOG_SIZE as u32)
-    ..SETTINGS_NVM_FLASH_OFFSET_RANGE.start;
+const NVM_PARTITION_SIZE: usize = SETTINGS_SIZE + ACTIVITY_LOG_SIZE;
+const NVM_PARTITION_RANGE: Range<u32> = (FLASH_SIZE - NVM_PARTITION_SIZE) as u32..FLASH_SIZE as u32;
+const ACTIVITY_LOG_NVM_FLASH_OFFSET_RANGE: Range<u32> = 0..ACTIVITY_LOG_SIZE as u32;
+const SETTINGS_NVM_FLASH_OFFSET_RANGE: Range<u32> =
+    ACTIVITY_LOG_SIZE as u32..NVM_PARTITION_SIZE as u32;
 
 #[cfg(feature = "pcb_rev1")]
 const LED_COUNT: usize = 12;
@@ -352,6 +351,7 @@ async fn storage_task(storage_resources: StorageResources) {
 
     storage::storage_manager::initialise_storage(
         flash_mutex,
+        NVM_PARTITION_RANGE.clone(),
         SETTINGS_NVM_FLASH_OFFSET_RANGE.clone(),
     )
     .await;

--- a/smartcoaster-bootloader/src/main.rs
+++ b/smartcoaster-bootloader/src/main.rs
@@ -35,16 +35,6 @@ fn main() -> ! {
     let active_offset = config.active.offset();
     let bl: BootLoader = BootLoader::prepare(config);
 
-    info!("Marking ok");
-
-    // TODO - move this into the firmware, it's done here for now as the interfaces aren't yet compatable with the applications flash management
-    let fw_config = FirmwareUpdaterConfig::from_linkerfile_blocking(&flash, &flash);
-    let mut aligned = AlignedBuffer([0; 1]);
-    let mut updater = BlockingFirmwareUpdater::new(fw_config, &mut aligned.0);
-    updater
-        .mark_booted()
-        .expect("Unabled to mark update successful");
-
     info!("Booting application");
 
     unsafe { bl.load(embassy_rp::flash::FLASH_BASE as u32 + active_offset) }


### PR DESCRIPTION
Move to using flash partition for NVM. Marks the boot successful in the application rather than the bootloader.